### PR TITLE
change "scaleInt" Conversion to round values

### DIFF
--- a/src/yahka.functions/conversion.scale.ts
+++ b/src/yahka.functions/conversion.scale.ts
@@ -36,7 +36,7 @@ export class TIoBrokerConversion_Scale extends TIOBrokerConversionBase implement
         let ioBrokerMin = this.parameters["iobroker.min"];
         let newValue = ((num - ioBrokerMin) / (ioBrokerMax - ioBrokerMin)) * (homeKitMax - homeKitMin) + homeKitMin;
         this.adapter.log.debug(`${this.logName}: converting value to homekit: ${value} to ${newValue}`);
-        return newValue;
+        return this.logName === "scaleInt" ? Math.round(newValue) : newValue;
     }
     toIOBroker(value) {
         let num: number = TIOBrokerConversionBase.castToNumber(value);
@@ -46,6 +46,6 @@ export class TIoBrokerConversion_Scale extends TIOBrokerConversionBase implement
         let ioBrokerMin = this.parameters["iobroker.min"];
         let newValue = ((num - homeKitMin) / (homeKitMax - homeKitMin)) * (ioBrokerMax - ioBrokerMin) + ioBrokerMin;
         this.adapter.log.debug(`${this.logName}: converting value to ioBroker: ${value} to ${newValue}`);
-        return newValue;
+        return this.logName === "scaleInt" ? Math.round(newValue) : newValue;
     }
 }


### PR DESCRIPTION
Hi

I use the Hue-extended adapter and it seems that this adapter needs integers values to function. 
In the yahka adapter exists a conversion function with name "scaleInt", i think it should convert to integer, but the math calculation produces float values. So I added an Math.round() to the calculated value if the conversion function name is "scaleInt".

What do you think?